### PR TITLE
Fixing running deploy-subgraph.sh script

### DIFF
--- a/.github/workflows/allthekeeps-testnet.yml
+++ b/.github/workflows/allthekeeps-testnet.yml
@@ -49,14 +49,14 @@ jobs:
       - name: Deploy latest subgraph to thegraph.com
         working-directory: ./keep-subgraph
         run: | 
-          CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY=${{ secrets.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY }} \
-          ETH_RPC_URL=${{ secrets.ETH_RPC_URL }} \ 
-          SUBGRAPH_DEPLOY_KEY=${{ secrets.SUBGRAPH_DEPLOY_KEY }} \ 
-          SUBGRAPH_SLUG=${{ secrets.SUBGRAPH_SLUG }} \ 
-          KEEP_CORE_VERSION=${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }} \
-          KEEP_ECDSA_VERSION=${{ steps.upstream-builds-query.outputs.keep-ecdsa-contracts-version }} \
-          KEEP_TBTC_VERSION=${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }} \
-            ./deploy-subgraph.sh
+          export CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY=${{ secrets.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY }}
+          export ETH_RPC_URL=${{ secrets.ETH_RPC_URL }}
+          export SUBGRAPH_DEPLOY_KEY=${{ secrets.SUBGRAPH_DEPLOY_KEY }}
+          export SUBGRAPH_SLUG=${{ secrets.SUBGRAPH_SLUG }}
+          export KEEP_CORE_VERSION=${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }}
+          export KEEP_ECDSA_VERSION=${{ steps.upstream-builds-query.outputs.keep-ecdsa-contracts-version }}
+          export KEEP_TBTC_VERSION=${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }}
+          ./deploy-subgraph.sh
 
       - name: YARN build
         run: ./install-dapp.sh

--- a/.github/workflows/allthekeeps-testnet.yml
+++ b/.github/workflows/allthekeeps-testnet.yml
@@ -48,15 +48,15 @@ jobs:
 
       - name: Deploy latest subgraph to thegraph.com
         working-directory: ./keep-subgraph
-        run: | 
-          export CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY=${{ secrets.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY }}
-          export ETH_RPC_URL=${{ secrets.ETH_RPC_URL }}
-          export SUBGRAPH_DEPLOY_KEY=${{ secrets.SUBGRAPH_DEPLOY_KEY }}
-          export SUBGRAPH_SLUG=${{ secrets.SUBGRAPH_SLUG }}
-          export KEEP_CORE_VERSION=${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }}
-          export KEEP_ECDSA_VERSION=${{ steps.upstream-builds-query.outputs.keep-ecdsa-contracts-version }}
-          export KEEP_TBTC_VERSION=${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }}
-          ./deploy-subgraph.sh
+        env:
+          CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY: ${{ secrets.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY }}
+          ETH_RPC_URL: ${{ secrets.ETH_RPC_URL }}
+          SUBGRAPH_DEPLOY_KEY: ${{ secrets.SUBGRAPH_DEPLOY_KEY }}
+          SUBGRAPH_SLUG: ${{ secrets.SUBGRAPH_SLUG }}
+          KEEP_CORE_VERSION: ${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }}
+          KEEP_ECDSA_VERSION: ${{ steps.upstream-builds-query.outputs.keep-ecdsa-contracts-version }}
+          KEEP_TBTC_VERSION: ${{ steps.upstream-builds-query.outputs.tbtc-contracts-version }}
+        run: ./deploy-subgraph.sh
 
       - name: YARN build
         run: ./install-dapp.sh


### PR DESCRIPTION
The way it was written didn't run the `deploy-subgraph.sh` script. To keep env vars in separate lines with a script name we need to use `export` cmd.