### PR TITLE
Moving to the `main` branch

### DIFF
--- a/install-repositories.sh
+++ b/install-repositories.sh
@@ -8,9 +8,3 @@ LOG_END='\n\e[0m' # new line + reset color
 printf "${LOG_START}Initializing submodules...${LOG_END}"
 
 git submodule update --init --recursive --remote --rebase --force
-
-printf "${LOG_START}Switching to 'for-allthekeeps-on-ropsten' branch...${LOG_END}"
-
-cd ./keep-subgraph
-git checkout for-allthekeeps-on-ropsten
-git pull


### PR DESCRIPTION
Depends on https://github.com/keep-network/keep-subgraph/pull/1

Once the PR above is merged to the `main` branch, we won't need to checkout the `for-allthekeeps-on-ropsten` branch.