### PR TITLE
Update query for `keep-core-contracts-version`

### DIFF
--- a/.github/workflows/allthekeeps-testnet.yml
+++ b/.github/workflows/allthekeeps-testnet.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
           query: |
-            keep-core-contracts-version = github.com/keep-network/keep-core/solidity#version
+            keep-core-contracts-version = github.com/keep-network/keep-core/solidity-v1#version
             keep-ecdsa-contracts-version = github.com/keep-network/keep-ecdsa/solidity#version
             tbtc-contracts-version = github.com/keep-network/tbtc/solidity#version
 


### PR DESCRIPTION
Query updated after change of the structure in `keep-core` (renaming
`solidity` to `solidity-v1`) resulting in update of the name of the
module with `keep-core` v1 contracts.

Ref:
https://github.com/keep-network/keep-core/pull/2610
https://github.com/keep-network/ci/pull/21